### PR TITLE
Fix clicking the nav bar

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -494,6 +494,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	z-index: -1;
 }
 
 .mobile-timeline {


### PR DESCRIPTION
However, this breaks selecting the text in the timeline, which seems like a reasonable tradeoff to me.

Before:
![f31245ac-773f-410d-a989-1b427787f923](https://github.com/user-attachments/assets/fb14137a-7cbf-4384-9cf1-b65bc2f06907)

After:
![120ce0c9-3620-40d9-ba95-5ceff338c9af](https://github.com/user-attachments/assets/5b1b5605-7837-434b-a80d-ea758de6c55a)
